### PR TITLE
Add function for Start, Complete and Close Voting Session

### DIFF
--- a/companion/HELP.md
+++ b/companion/HELP.md
@@ -41,6 +41,9 @@ This module will connect to the Shure MXCWAPT to provide feedback status as well
 - Turn on flash to identify APT
 - Turn on flash to identify a seat
 - Turn next microphone in request list on
+- Start voting session
+- Complete voting session
+- Clear voting results screen
 
 ### Available feedbacks/triggers
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "shure-mxcw",
-	"version": "1.1.0",
+	"version": "1.1.1",
 	"main": "src/index.js",
 	"type": "module",
 	"scripts": {
@@ -20,5 +20,6 @@
 		"@companion-module/tools": "~2.0",
 		"prettier": "^3.0.0"
 	},
-	"prettier": "@companion-module/tools/.prettierrc.json"
+	"prettier": "@companion-module/tools/.prettierrc.json",
+	"packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }

--- a/src/actions.js
+++ b/src/actions.js
@@ -79,6 +79,20 @@ export function updateActions() {
 				this.sendCommand(`SET CLEAR_REQUEST_LIST TRUE`)
 			},
 		},
+		close_voting_results: {
+            name: 'Close Voting Results',
+            options: [],
+            callback: async () => {
+                this.sendCommand(`SET CLOSE_VOTING_RESULTS TRUE`)
+            },
+        },
+		complete_vote: {
+            name: 'Complete Voting Session',
+            options: [],
+            callback: async () => {
+                this.sendCommand(`SET COMPLETE_VOTE TRUE`)
+            },
+        },
 		dante_input_agc: {
 			name: 'Set Dante input AGC',
 			options: [Fields.Dante, Fields.OnOff],
@@ -259,6 +273,21 @@ export function updateActions() {
 				this.sendCommand(`SET ${options.seat} SEAT_NAME {${options.id}}`)
 			},
 		},
+		start_vote: {
+            name: 'Start Voting',
+            options: [
+                {
+                    type: 'number',
+                    label: 'Voting Mode ID', // could improve this by adding a dropdown with the available voting modes - pull from < GET n VOTING_CONFIGURATION_NAME >
+                    id: 'voteNumber',
+                    min: 0,
+                    required: true,
+                },
+            ],
+            callback: async ({ options }) => {
+                this.sendCommand(`SET START_VOTE ${options.voteNumber}`)
+            },
+        },
 		wdu_lock_welcome: {
 			name: 'Set welcome screen lock status',
 			options: [Fields.EnabledDisabled],


### PR DESCRIPTION
This PR adds functionality for starting, stopping and closing a voting session. While more voting commands exist, I did not have time to implement them personally.

The start voting function takes an ID which corresponds to a preset voting config made in the Web UI. Complete voting session is akin to stopping voting, and displays the results on connected web clients. Complete voting session closes the results page on all but delegate transcievers.

This was tested at my installation in Florida and worked correctly.