### PR TITLE
feat: optionally use seat numbers from input field

### DIFF
--- a/src/actions.js
+++ b/src/actions.js
@@ -125,9 +125,9 @@ export function updateActions() {
 		},
 		exclusive_mute: {
 			name: 'Assign exclusive mute',
-			options: [this.SEATS_FIELD, Fields.OnOff],
+			options: [this.SEATS_FIELD, this.SEAT_INPUT_FIELD, Fields.OnOff],
 			callback: async ({ options }) => {
-				this.sendCommand(`SET ${options.seat} FLASH ${options.choice}`)
+				this.sendCommand(`SET ${await this.seatNumberFromChoiceOrInput(options)} FLASH ${options.choice}`)
 			},
 		},
 		flash_apt: {
@@ -139,9 +139,9 @@ export function updateActions() {
 		},
 		flash_seat: {
 			name: 'Turn on flash to identify a seat',
-			options: [this.SEATS_A_FIELD, Fields.OnOff],
+			options: [this.SEATS_A_FIELD, this.SEAT_INPUT_FIELD, Fields.OnOff],
 			callback: async ({ options }) => {
-				this.sendCommand(`SET ${options.seat} FLASH ${options.choice}`)
+				this.sendCommand(`SET ${await this.seatNumberFromChoiceOrInput(options)} FLASH ${options.choice}`)
 			},
 		},
 		global_mute: {
@@ -189,31 +189,31 @@ export function updateActions() {
 		},
 		mic_agc: {
 			name: 'Set microphone AGC',
-			options: [this.SEATS_A_FIELD, Fields.OnOff],
+			options: [this.SEATS_A_FIELD, this.SEAT_INPUT_FIELD, Fields.OnOff],
 			callback: async ({ options }) => {
-				this.sendCommand(`SET ${options.seat} MIC_AGC ${options.choice}`)
+				this.sendCommand(`SET ${await this.seatNumberFromChoiceOrInput(options)} MIC_AGC ${options.choice}`)
 			},
 		},
 		mic_gain: {
 			name: 'Set the microphone gain of conference unit',
-			options: [this.SEATS_A_FIELD, Fields.GainSet(10)],
+			options: [this.SEATS_A_FIELD, this.SEAT_INPUT_FIELD, Fields.GainSet(10)],
 			callback: async ({ options }) => {
 				let vol = 30 + options.gain
-				this.sendCommand(`SET ${options.seat} MIC_GAIN ${vol}`)
+				this.sendCommand(`SET ${await this.seatNumberFromChoiceOrInput(options)} MIC_GAIN ${vol}`)
 			},
 		},
 		mic_priority: {
 			name: 'Set microphone priority',
-			options: [this.SEATS_A_FIELD, Fields.Priority],
+			options: [this.SEATS_A_FIELD, this.SEAT_INPUT_FIELD, Fields.Priority],
 			callback: async ({ options }) => {
-				this.sendCommand(`SET ${options.seat} MIC_PRIORITY ${options.val}`)
+				this.sendCommand(`SET ${await this.seatNumberFromChoiceOrInput(options)} MIC_PRIORITY ${options.val}`)
 			},
 		},
 		mic_status: {
 			name: 'Set microphone status',
-			options: [this.SEATS_A_FIELD, Fields.OnOff],
+			options: [this.SEATS_A_FIELD, this.SEAT_INPUT_FIELD, Fields.OnOff],
 			callback: async ({ options }) => {
-				this.sendCommand(`SET ${options.seat} MIC_STATUS ${options.choice}`)
+				this.sendCommand(`SET ${await this.seatNumberFromChoiceOrInput(options)} MIC_STATUS ${options.choice}`)
 			},
 		},
 		next_mic_on: {
@@ -246,17 +246,17 @@ export function updateActions() {
 		},
 		role: {
 			name: 'Set role for device',
-			options: [this.SEATS_A_FIELD, Fields.Role],
+			options: [this.SEATS_A_FIELD, this.SEAT_INPUT_FIELD, Fields.Role],
 			callback: async ({ options }) => {
-				this.sendCommand(`SET ${options.seat} ROLE ${options.choice}`)
+				this.sendCommand(`SET ${await this.seatNumberFromChoiceOrInput(options)} ROLE ${options.choice}`)
 			},
 		},
 		seat_name: {
 			name: 'Set seat name',
 			tooltip: 'UTF-8 characters are allowed except for {,},<,>',
-			options: [this.SEATS_A_FIELD, Fields.Name],
+			options: [this.SEATS_A_FIELD, this.SEAT_INPUT_FIELD, Fields.Name],
 			callback: async ({ options }) => {
-				this.sendCommand(`SET ${options.seat} SEAT_NAME {${options.id}}`)
+				this.sendCommand(`SET ${await this.seatNumberFromChoiceOrInput(options)} SEAT_NAME {${options.id}}`)
 			},
 		},
 		wdu_lock_welcome: {

--- a/src/index.js
+++ b/src/index.js
@@ -337,6 +337,26 @@ class ShureMxcwInstance extends InstanceBase {
 			default: '1',
 			choices: this.CHOICES_SEATS_A,
 		}
+		this.SEAT_INPUT_FIELD = {
+			type: 'textinput',
+			label: 'Seat Number',
+			useVariables: true,
+			id: 'seatInput',
+			default: '1',
+			isVisible: (options) => options.seat === 'fromInput',
+		}
+	}
+
+	/**
+	 * Return the selected seat number from the options.
+	 * If the selected dropdown option is 'fromInput', it will
+	 * return the value from the seatInput field.
+	 */
+	async seatNumberFromChoiceOrInput(options) {
+		if (options.seat === 'fromInput') {
+			return await this.parseVariablesInString(options.seatInput)
+		}
+		return options.seat
 	}
 
 	/**
@@ -345,6 +365,13 @@ class ShureMxcwInstance extends InstanceBase {
 	setupSeatChoices() {
 		this.CHOICES_SEATS = []
 		this.CHOICES_SEATS_A = []
+
+		const fromInputChoiceOption = {
+			id: 'fromInput',
+			label: 'Seat Number from Input',
+		}
+		this.CHOICES_SEATS.push(fromInputChoiceOption)
+		this.CHOICES_SEATS_A.push(fromInputChoiceOption)
 
 		this.CHOICES_SEATS_A.push({ id: 0, label: 'All Seats' })
 


### PR DESCRIPTION
Hey there & thanks for your awesome module!

As suggested in #16, I'd also find it quite handy to be able to use a dynamic seat number. I took the freedom to implement it and would love to hear your feedback :)

This PR adds a selection option "Seat Number from Input" to the seat number dropdown. If selected, a text input field appears allowing users to enter a seat number manually. This can also be an expression e.g. a variable.

![Screenshot showing the new input field](https://github.com/user-attachments/assets/555d6f2a-1548-498c-b5e6-8bf094305dc3)

As of now, there is no kind of validation. Therefore – if a user chooses to enter a garbage value – this would also be sent to the Shure system. Please let me know if you see a need for validation here – I opted for not implementing it giving the user complete freedom.

I've tested it in my local installation and it worked fine.